### PR TITLE
Don't crash if an electricity or gas reading doesn't exist

### DIFF
--- a/bulb_energy_prometheus/main.py
+++ b/bulb_energy_prometheus/main.py
@@ -29,8 +29,16 @@ async def main(api_token):
         while True:
             with refresh_time.time():
                 await device.status.refresh()
-            gauge_electricity.set(device.status.values.get("energy"))
-            gauge_gas.set(device.status.values.get("gasMeter"))
+            if device.status.values.get("energy"):
+                gauge_electricity.set(device.status.values.get("energy"))
+            else:
+                print("Can't get electricity reading")
+
+            if device.status.values.get("gasMeter"):
+                gauge_gas.set(device.status.values.get("gasMeter"))
+            else:
+                print("Can't get gas meter reading")
+
             await asyncio.sleep(10)
 
 


### PR DESCRIPTION
- We got our Bulb smart meter today and I was excited to try this exporter! Thanks for building it!
- Our smart meter doesn't have a gas reading yet because they're slow to come through. But I still wanted some electricity readings in Prometheus.
- Here's some basic log messages rather than a crash.

Before:

```
Starting...
Connected, running...
Traceback (most recent call last):
  File "/home/issyl0/.local/bin/bulb-energy-prometheus", line 11, in <module>
    load_entry_point('bulb-energy-prometheus==1.0', 'console_scripts', 'bulb-energy-prometheus')()
  File "/home/issyl0/.local/lib/python3.6/site-packages/bulb_energy_prometheus/main.py", line 49, in run
    loop.run_until_complete(main(os.environ["SMARTTHINGS_API_TOKEN"]))
  File "/usr/lib/python3.6/asyncio/base_events.py", line 484, in run_until_complete
    return future.result()
  File "/home/issyl0/.local/lib/python3.6/site-packages/bulb_energy_prometheus/main.py", line 33, in main
    gauge_gas.set(device.status.values.get("gasMeter"))
  File "/home/issyl0/.local/lib/python3.6/site-packages/prometheus_client/metrics.py", line 359, in set
    self._value.set(float(value))
TypeError: float() argument must be a string or a number, not 'NoneType'
```

After:

```
Starting...
Connected, running...
Can't get gas meter reading

[...]

> /metrics
bulb_electricity_used_kwh 4.168
bulb_gas_used_units 0.0
```
